### PR TITLE
Change license from CC0 to CC-BY-SA 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ The PDF will appear in `~/OpenReferral/pdf/openreferral-[commit ID].pdf`
 
 ## License
 
-This work is licensed under the CC0 licenense, which is the "no copyright reserved" option in the Creative Commons toolkit - it effectively means relinquishing all copyright and similar rights that you hold in a work and dedicating those rights to the public domain. To view a copy of this license, visit [Creative Commons License](https://creativecommons.org/publicdomain/zero/1.0/).
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 license (CC BY-SA 4.0). This license enables free usage and adaptation of the material; it also requires attribution to Open Referral, the indication of any changes, and preservation of this license in any adapted versions derived from the original. [Read more about this license here](http://creativecommons.org/licenses/by-sa/4.0/), with [full legal code here](http://creativecommons.org/licenses/by-sa/4.0/legalcode)
 
-We highly encourage you to use the same license for your data.
 
 
 


### PR DESCRIPTION
I’m proposing a change in license for the Human Services Data Specification. Currently, HSDS v0.9 is licensed CC0 — in other words, it’s content in the public domain with no conditions on usage. 

I propose that we license the Human Service Data Standard as Creative Commons 4.0 Attribution-ShareAlike: https://creativecommons.org/licenses/by-sa/4.0/legalcode

Licensing is generally a tricky issue, and it’s going to be especially complex for us in the Open Referral Initiative, as we are working across multiple layers of content, data, and software, each of which has different attributes relevant for licensing purposes.

While we want to encourage free and widespread usage of this model, and we also want to ensure that such development occurs in a way that is interoperable and freely available — especially in this formative phase. The CC BY-SA 4.0 license ensures that any changes will preserve the openness of this format, as per our mission and values.

This proposal is intended to be a deliberate starting point from which we’ll conduct further research and deliberation into licensing implications. The reason this change is important to make now is that it’s much easier to relax this Share-Alike condition in the future; the other way around (starting from no conditions and trying to adopt restrictions that preserve open source licensing and attribution) may quickly become logistically infeasible.

I’ve composed [this memo about licensing in the Open Referral Initiative](https://docs.google.com/document/d/1W81WtFVgnIIz_ko8PVtvoQrnb-_AbwlKTDPGvPo6dIk/edit) to frame the outset of this conversation. If you're interested in discussing licensing implications, please reach out or comment in that document -- and let's discuss.
