### PR TITLE
Ensure that all text is extracted for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ First, do a local build, then:
 
 ```
 cd docs
+make gettext
 sphinx-intl update-txconfig-resources --transifex-project-name open-referral-1-0
 ```
 

--- a/docs/.tx/config
+++ b/docs/.tx/config
@@ -7,3 +7,8 @@ file_filter = locale/<lang>/LC_MESSAGES/index.po
 source_file = _build/locale/index.pot
 source_lang = en
 
+[open-referral-1-0.reference]
+file_filter = locale/<lang>/LC_MESSAGES/reference.po
+source_file = _build/locale/reference.pot
+source_lang = en
+


### PR DESCRIPTION
Managed to fix this in the end \o/

I've also pushed all the strings up to transifex - https://www.transifex.com/OpenDataServices/open-referral-1-0/translate/#es/reference/100373782