### PR TITLE
Removed foreign key "location_id" from service

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -320,13 +320,6 @@
                                 "resource": "program",
                                 "fields": "id"
                             }
-                        },
-                        {
-                            "fields": "location_id",
-                            "reference": {
-                                "resource": "location",
-                                "fields": "id"
-                            }
                         }
                     ]
                 }


### PR DESCRIPTION
I noticed that `location_id` was removed from the `service` table in 1.1 but was still listed as a foreign key.