### PR TITLE
Fixed broken links in documentation to HSDA definition files.

### DIFF
--- a/docs/hsda/hsda-bulk.md
+++ b/docs/hsda/hsda-bulk.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Bulk
 
-The HSDA bulk protocol is defined by [openapi-hsda-bulk.yaml](../static/openapi-hsda-bulk.yaml). The details below show the available methods and responses. 
+The HSDA bulk protocol is defined by [openapi-hsda-bulk.yaml](https://github.com/openreferral/api-specification/blob/master/_data/api-commons/openapi-hsda-bulk.yaml). The details below show the available methods and responses. 
 
 This is a service for handling bulk loading of data into any HSDA service, allowing each POST and PUT to be queued up as a job, and be run on schedule, or based upon other events.
 

--- a/docs/hsda/hsda-management.md
+++ b/docs/hsda/hsda-management.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Management
 
-The HSDA management protocol is defined by [openapi-hsda-management.yaml](../static/openapi-hsda-management.yaml). The details below show the available methods and responses. 
+The HSDA management protocol is defined by [openapi-hsda-management.yaml](../../api-specification/_data/api-commons/openapi-hsda-management.yaml). The details below show the available methods and responses. 
 
 This is a HSDA service specifically intended to assist in managing HSDA access, allowing users to get at resources made available any HSDA implementation. Providing the ability to manage users, and the HSDA services they have access to. 
 

--- a/docs/hsda/hsda-meta.md
+++ b/docs/hsda/hsda-meta.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Meta 
 
-The HSDA meta protocol is defined by [openapi-hsda-meta.yaml](../static/openapi-hsda-meta.yaml). The details below show the available methods and responses. 
+The HSDA meta protocol is defined by [openapi-hsda-meta.yaml](../../api-specification/_data/api-commons/openapi-hsda-meta.yaml). The details below show the available methods and responses. 
 
 This is a HSDA service specifically intended to manage the meta data around human services data API operations. Essentially this is a logging system, providing access to data about what API calls are made, managing individual resources, as well as any other service in use association with HSDA operations.
 

--- a/docs/hsda/hsda-orchestration.md
+++ b/docs/hsda/hsda-orchestration.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Orchestration
 
-The HSDA orchestration protocol is defined by [openapi-hsda-orchestration.yaml](../static/openapi-hsda-orchestration.yaml). The details below show the available methods and responses. 
+The HSDA orchestration protocol is defined by [openapi-hsda-orchestration.yaml](../../api-specification/_data/api-commons/openapi-hsda-orchestration.yaml). The details below show the available methods and responses. 
 
 This is a HSDA sevice specifically intended to manage orchestration around HSDA operations, enabling the system to become a two-way street, pushing data outside individual implementations. The system uses webhooks, and events to understand changes made to the HSDA system, and the data stored within.
 

--- a/docs/hsda/hsda-search.md
+++ b/docs/hsda/hsda-search.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Search
 
-The HSDA search protocol is defined by [openapi-hsda-search.yaml](../static/openapi-hsda-search.yaml). The details below show the available methods and responses. 
+The HSDA search protocol is defined by [openapi-hsda-search.yaml](../../api-specification/_data/api-commons/openapi-hsda-search.yaml). The details below show the available methods and responses. 
 
 In general, responses should be a collection of organization, services and/or location arrays. Applications may choose how complete the records they provide in response are. 
 

--- a/docs/hsda/hsda-taxonomy.md
+++ b/docs/hsda/hsda-taxonomy.md
@@ -3,7 +3,7 @@
 ```
 # HSDA Taxonomy 
 
-The HSDA taxonomy protocol is defined by [openapi-hsda-taxonomy.yaml](../static/openapi-hsda-taxonomy.yaml). The details below show the available methods and responses. 
+The HSDA taxonomy protocol is defined by [openapi-hsda-taxonomy.yaml](../../api-specification/_data/api-commons/openapi-hsda-taxonomy.yaml). The details below show the available methods and responses. 
 
 This is a separate HSDA service for working with taxonomy across all the core human services resources, support any categorization or taxonomy, and allowing for filtering of services by taxonomy.
 

--- a/docs/hsda/hsda-utility.md
+++ b/docs/hsda/hsda-utility.md
@@ -4,7 +4,7 @@
 
 # HSDA Utility
 
-The HSDA utility protocol is defined by [openapi-hsda-utility.yaml](../static/openapi-hsda-utility.yaml). The details below show the available methods and responses. 
+The HSDA utility protocol is defined by [openapi-hsda-utility.yaml](../../api-specification/_data/api-commons/openapi-hsda-utility.yaml). The details below show the available methods and responses. 
 
 You can also [explore this using our OpenAPI viewer](../../_static/swagger/?url=../openapi-hsda-utility.yaml). 
 


### PR DESCRIPTION
This PR fixes broken links to the OpenAPI definitions for:
HSDA Search,
HSDA Taxonomy,
HSDA Bulk,
HSDA Orchestrations,
HSDA Meta,
HSDA Management