### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Learn more about the why's, how's, and who's of the Open Referral Initiative in 
 
 **Join Open Referral's Community of Practice**
 
-* We are formally convened [in this Google Group](https://groups.google.com/forum/#!forum/openreferral).
+* We are formally convened [in this Google Group](https://groups.google.com/g/openreferral).
 * You can also join [our Slack team](https://openreferral.org/get-involved/join-our-slack-team/).
 * Sign up for our email newsletter [on our homepage](https://openreferral.org/).
 


### PR DESCRIPTION
The URL for the Google Group does not work. I have suggested a change here to https://groups.google.com/g/openreferral as I had to go to Google to find the correct URL.