### PR TITLE
docs/conf: Replace deprecated html_context with html_css_files in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,13 +138,10 @@ html_static_path = ['_static']
 
 html_theme = 'sphinx_rtd_theme'
 
-html_context = { 
-    'css_files': [
-        'https://media.readthedocs.org/css/sphinx_rtd_theme.css',
-        'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
-        '_static/theme_overrides.css',
-    ],
-}
+html_css_files = ['https://media.readthedocs.org/css/sphinx_rtd_theme.css',
+                  'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
+                  '_static/theme_overrides.css',
+                 ]
 
 html_js_files = ["custom.js"]
 


### PR DESCRIPTION
To fix issue with list styles not rendering correctly

https://github.com/openreferral/specification/issues/315