### PR TITLE
Integrate a swagger page

### DIFF
--- a/docs/extras/openapi.html
+++ b/docs/extras/openapi.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="SwaggerUI"
+    />
+    <title>SwaggerUI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.18.1/swagger-ui.css" />
+  </head>
+  <body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@4.18.1/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://unpkg.com/swagger-ui-dist@4.18.1/swagger-ui-standalone-preset.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: 'openapi30.json',
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "StandaloneLayout",
+      });
+    };
+  </script>
+  </body>
+</html>

--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -1,21 +1,14 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.0",
   "info": {
-    "title": "REQUIRED -- TITLE OF YOUR API HERE",
-    "version": "REQUIRED -- The version of this document. This is distinct from the OpenAPI Schema version and the version of your API.",
-    "summary": "SUMMARY HERE",
-    "description": "DESCRIPTION HERE",
-    "contact": {
-      "name": "YOUR CONTACT NAME HERE",
-      "url": "YOUR CONTACT URL HERE",
-      "email": "YOUR CONTACT EMAIL HERE"
-    },
+    "title": "HSDS OpenAPI",
+    "version": "3.0",
+    "description": "",
     "license": {
-      "name": "REQUIRED -- THE LICENSE OF YOUR API",
-      "url": "Url to the license used; mutually exclusive to the identifier field if used."
+      "name": "Creative Commons Attribution Share-Alike 4.0 license",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
     }
   },
-  "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
   "paths": {
     "/": {
       "get": {

--- a/docs/hsds/api_reference.md
+++ b/docs/hsds/api_reference.md
@@ -3,6 +3,11 @@ API Reference
 
 The API reference provides an [OpenAPI](https://www.openapis.org/) specification that can be used as a blueprint for the design or adaptation of API platforms to provide read or read/write access to information on organizations, services, locations and the details about them. The API protocol  provides most of the functionality needed for simple access and exchange of data.
 
+ 
+```{eval-rst}
+Along with this reference, there is `a swagger ui version of the API <../openapi.html>`_
+```
+
 The source of the specification is found on [GitHub](https://github.com/openreferral/specification/tree/3.0-dev/schema/openapi.json) and [issues can be raised in the issue tracker](https://github.com/openreferral/specification/issues).
 
 ## Lists


### PR DESCRIPTION
In the end, it was not too bad to add a swagger version of the reference page.  See http://docs.openreferral.org/en/openapi30/hsds/api_reference.html for the link to it.


