### PR TITLE
Docs: Added in definition of html_baseurl

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,11 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
+# We need to define the html_baseurl variable now as Read the docs have stopped injecting this into conf.py
+# see https://about.readthedocs.com/blog/2024/07/addons-by-default/
+
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #


### PR DESCRIPTION
Added in html_baseurl variable in response to the upcoming RTD changes which will break builds

* https://about.readthedocs.com/blog/2024/07/addons-by-default/

I have built the branch and everything appears fine: tables, image, and schemas are all rendering as expected.

* http://docs.openreferral.org/en/rtd-config-update/

I think this should be merged in now to ensure that our docs don't stop building in October. There are no versioning implications for the specification, as we are updating infrastructure rather than making any changes to the docs or the schemas.
