### PR TITLE
Schema: Added enum values to field descriptions

### DIFF
--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -9,6 +9,7 @@ TODO: update link to this
 
 ### Backwards compatible schema changes
 
+* Descriptions for `address.address_type`, `location.location_type`, `schedule.wkst`, and `schedule.freq` have been updated to include their enum values.
 
 ## [v3.0](https://github.com/openreferral/specification/milestone/7)
 

--- a/schema/address.json
+++ b/schema/address.json
@@ -125,7 +125,7 @@
             "name": "address_type",
             "type": "string",
             "title": "Address Type",
-            "description": "The type of address which may be physical, postal, or virtual.",
+            "description": "The type of address which may be `physical`, `postal`, or `virtual`.",
             "constraints": {
                 "unique": false
             },

--- a/schema/location.json
+++ b/schema/location.json
@@ -26,7 +26,7 @@
             "name": "location_type",
             "type": "string",
             "title": "Location Type",
-            "description": "The type of location, which may be either physical, postal, or virtual.",
+            "description": "The type of location, which may be either `physical`, `postal`, or `virtual`.",
             "constraints": {
                 "unique": false
             },

--- a/schema/schedule.json
+++ b/schema/schedule.json
@@ -128,7 +128,7 @@
             "name": "wkst",
             "type": "string",
             "title": "Week Start",
-            "description": "iCal - The two-letter code for the day on which the week starts.",
+            "description": "iCal - The two-letter code for the day on which the week starts: `MO`, `TU`, `WE`, `TH`, `FR`, `FR`, `SA`, `SU`",
             "constraints": {
                 "unique": false
             },
@@ -147,7 +147,7 @@
             "name": "freq",
             "type": "string",
             "title": "Frequency",
-            "description": "iCal - How often the frequency repeats.",
+            "description": "iCal - How often the frequency repeats. Values can be `WEEKLY` or `MONTHLY`",
             "constraints": {
                 "unique": false
             },


### PR DESCRIPTION
**Related issues**

* Fixes #234
* Fixes #271

**Description**

HSDS contains several fields where the values must be taken from
enumerated values. These are represented in the schemas with `enum`
properties.

There is currently no documentation for these values, so I have added
them to the `description` property of each field. This gives some inline
documentation where appropriate without changing the semantics of the
relevant fields.

**Merge checklist**

This PR is designed to be merged into the `3.1-dev` staging branch so compiling the schemas should be performed at a later date to take into account all other schema changes.

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog

If you have edited any schema files:

- [ ] Run `hsds_schema.py` to update `datapackage.json` and example files
- [ ] Update the [logical model](http://docs.openreferral.org/en/latest/hsds/logical_model/) page if relevant
