### PR TITLE
Replace/Remove links to private Google Docs in Changelog page

### DIFF
--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -122,12 +122,12 @@ TODO: update link to this
 * Bug fixes to schema and documentation
 * Removed redundant documentation pages
 
-## [v1.0](https://docs.google.com/document/d/1dkipRm_YL3K28oTSG-NFZRMHYiv10ZZJzJlakZglOyc/edit?usp=sharing)
+## [v1.0](https://github.com/openreferral/specification/releases/tag/1.0)
 
 * Final version
 * Changed relationship between location and service from 1:n to n:m
 
-## [v0.9](https://docs.google.com/document/d/1jbgO92cPAUygQI-0_DtLXrdPQKbPNNIkxDr-3WvdFNE/edit?usp=sharing)
+## v0.9
 
 * Changes based on public comments in v0.8 include:
     - revising revising schedule entities and attributes  as recommended,
@@ -137,11 +137,11 @@ TODO: update link to this
 * Released on github as a markdown document
 * Added a datapackage.json example on github
 
-## [v0.8](https://docs.google.com/document/d/1gmNS4pBvkX4cI2wtH3Qco3uGF4LLTq1OJ0Pb_CLuxlk/edit?usp=sharing)
+## v0.8
 
 * Added formatting specification for address, phone, description
 
-## [v0.4 - v0.7](https://docs.google.com/document/d/1xTqNm3ShgL6vQtknMmkCNJeWapekrLxd1qpEa8WiEIk/edit?usp=sharing)
+## v0.4 - v0.7
 
 * Updated data model based on reviewer comments
 * Tested logical model by importing data from iCarol database
@@ -150,7 +150,7 @@ TODO: update link to this
 * Tested OE taxonomy by querying the service_taxonomy to return the related service
 * Provided test scripts and example data
 
-## [v0.3](https://docs.google.com/document/d/1RH89UY7FDndivWNmtQkql4tdRTwYnCZluyu8itp5nTw/edit?usp=sharing)
+## v0.3
 
 * Refined logical model to conform to Boyce-Codd third normal form
 * Updated datapackage.json to match logical model
@@ -158,7 +158,7 @@ TODO: update link to this
 * Added section on NIEM and relation to specification
 * Made changes based on reviewer comments
 
-## [v0.2](https://docs.google.com/document/d/1z4jSLCoDIqvkKnazZVH_7qP_5HkcgKhnPJLu1mUZBgA/edit?usp=sharing)
+## v0.2
 
 * Added related standards
 * Added use cases based on persona
@@ -167,11 +167,11 @@ TODO: update link to this
 * Made changes from [comments](https://docs.google.com/spreadsheets/d/19Sf7DPMooO6edEm8FcIjSv6VeC1Ar55YDBvLTl-S4dE/edit?usp=sharing) collected during the second RFC period
 * Added Appendix C: Tabular  Data Package description
 
-## [v0.1](https://docs.google.com/document/d/18vdB0DUvBfp6UcYQ78KaMmN3Ei2riThJL48V7TTOHHQ/edit?usp=sharing)
+## v0.1
 
 * Changes from comment period, workshop comments, and a running [summary of comments](https://docs.google.com/spreadsheets/d/19Sf7DPMooO6edEm8FcIjSv6VeC1Ar55YDBvLTl-S4dE/edit?usp=sharing)
 * Directly references [RFC4180](http://tools.ietf.org/html/rfc4180) for CSV formatting
 
-## [v0.0](https://docs.google.com/document/d/1RwHkuPeG5cztk-gcofuqsXRxWaTYZeHa8mLjC2doCwk/edit?usp=sharing)
+## v0.0
 
 No changes.


### PR DESCRIPTION
**Related issues**

* Fixes #241

**Description**

The HSDS Changelog headers attempt to link off to further information surrounding the release of that version. However, versions 1.0 downwards linked off to private google docs.

HSDS has only been semi-consistent in creating releases on Github for versions. Some version headers link to issue queries filtered by milestones. This is acceptable where no release exists, however others link off to private, non-public, Google docs.

I have replaced the 1.0 link to the official GH release link, and removed the others for which there is no milestone, label, or release tag.

This means that for versions `0.x` down, there are currently no header links. Links to the GDocs remain in the body of the changelog for that version. In the future, if these details are pulled through onto a public page or backported into Github; we can modify the headings with new links.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [ ] Update the changelog

If you have edited any schema files:

- [ ] Run `hsds_schema.py` to update `datapackage.json` and example files
- [ ] Update the [logical model](http://docs.openreferral.org/en/latest/hsds/logical_model/) page if relevant
