### PR TITLE
Guidance page on docs to signpost database schema files

### DIFF
--- a/docs/hsds/database_schemas.md
+++ b/docs/hsds/database_schemas.md
@@ -1,0 +1,14 @@
+Database Schemas
+=================
+
+```{note}
+This page is *non-normative*, which means that it doesn't form part of the standard; if there is any ambiguity, the standard takes precedence. This page may be updated at any time in response to community demand.
+```
+
+HSDS is an exchange format designed to standardise the format for outputting machine-readable data about human services. Therefore systems which output HSDS are not expected to maintain a particular internal database or storage schema. As long as your published data matches HSDS &ndash; you can design your systems to operate however you wish.
+
+This being established, we provide some pre-rolled database schemas in order to support people and organizations bootstrapping systems which will work with HSDS data. We provide these in the form of `.sql` query files which &mdash; when executed in an appropriate environment &mdash; will generate database schemas with tables useful for storing and retrieving HSDS data. We geneate these files directly from the HSDS schema files, so they update as we release new versions of the specification.
+
+You can find the latest version of these files in the `/database` directory of the HSDS Specification Github repository. We provide versions for each SQL and PostgreSQL format databases. The files for HSDS version 3.1 are linked below:
+
+* [Database schemas for HSDS 3.1](https://github.com/openreferral/specification/tree/3.1/database)

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ Contents:
    hsds/extending
    hsds/using_profiles
    hsds/field_guidance
+   hsds/database_schemas
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
**Related issues**

* Fixes #276

**Description**

This PR adds a new page to the Implementation Guidance section of the HSDS docs. This page signposts the existance of the auto-generated HSDS database schema files, which may be used to rapidly format a database for representing HSDS data in a tabular form.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [ ] Update the changelog

If you have edited any schema files:

- [ ] Run `hsds_schema.py` to update `datapackage.json` and example files
- [ ] Update the [logical model](http://docs.openreferral.org/en/latest/hsds/logical_model/) page if relevant
