### PR TITLE
Add License page to docs

### DIFF
--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -1,0 +1,6 @@
+License
+===============
+
+The content of this documentation site, the HSDS schema files, and associated artefacts found in the [specification repository](https://github.com/openreferral/specification) are released under the [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) license.
+
+Other artifacts produced by Open Referral such as software, literature, or graphics (among other things) may be released under different licenses more appropriate for that domain. Open Referral strives to embody our [core values](https://openreferral.org/about/our-values-and-principles/)  of *Accessibility*, *Interoperability*, *Reliability*, and *Sustainability* through the licensing we choose for our projects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,5 +96,6 @@ Contents:
    about/specification-governance
    about/credits
    about/privacy-notice
+   about/license
 ```
 


### PR DESCRIPTION
**Related issues**

* Fixes #495
* Fixes #287

**Description**

I added a new page to the About section called *License*, which states that the contents of the docs site and the specification repo are released under the CC-BY-SA 4.0 license.

After reading the following doc, I also added a brief paragraph saying that OR may choose to release some artifacts under more specific or more appropriate licenses and linked back to the values and principles page of the OR website.

* https://docs.google.com/document/d/1W81WtFVgnIIz_ko8PVtvoQrnb-_AbwlKTDPGvPo6dIk/edit
