### PR TITLE
Fix problem seen where flatterer 0.18.0 does not exist any more.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ docutils==0.17.1
     #   sphinxcontrib-opendataservices-jsonschema
 erd-from-json-table-schema==0.2.0
     # via -r requirements.in
-flatterer==0.18.0
+flatterer==0.18.2
     # via hsds-schema-tools
 fqdn==1.5.1
     # via jsonschema
@@ -54,6 +54,8 @@ idna==3.4
 ijson==3.2.0.post0
     # via flatterer
 imagesize==1.4.1
+    # via sphinx
+importlib-metadata==8.5.0
     # via sphinx
 isoduration==20.11.0
     # via jsonschema
@@ -134,6 +136,8 @@ rfc3987==1.3.8
     # via jsonschema
 ruamel-yaml==0.17.21
     # via check-jsonschema
+ruamel-yaml-clib==0.2.12
+    # via ruamel-yaml
 six==1.16.0
     # via
     #   python-dateutil
@@ -197,6 +201,8 @@ urllib3==1.26.15
     #   transifex-client
 webcolors==1.13
     # via jsonschema
+zipp==3.20.2
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
(We don't understand why as there is no yanked message. we have contacted author to ask) To make a minimal change, upgrade to latest 0.18.X only. Extra packages: We aren't sure why pip-compile added these extra packages.

**Related issues**

<!-- Add links to related issues here. If you want an issue to be automatically closed when the PR is merged, use keywords (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->

**Description**

<!-- If the changes in the PR are not sufficiently explained by the related issues and commit messages, add a description here -->

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [ ] Update the changelog

If you have edited any schema files:

- [ ] Run `hsds_schema.py` to update `datapackage.json` and example files
- [ ] Update the [logical model](http://docs.openreferral.org/en/latest/hsds/logical_model/) page if relevant
