### PR TITLE
PATCH: make Page.empty a required field 

### DIFF
--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -826,7 +826,10 @@
             "type": "boolean",
             "description": "A Boolean value indicating if there is an empty result set"
           }
-        }
+        },
+        "required": [
+          "empty"
+        ]
       }
     },
     "parameters": {

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -3,6 +3,9 @@ Changelog
 
 This page provides the list of changes that have been made to the HSDS schema.
 
+## [v3.1.1](https://github.com/openreferral/specification/releases/tag/v3.1.1)
+* Made Page.empty a required field for API responses
+
 ## [v3.1](https://github.com/openreferral/specification/releases/tag/v3.1)
 
 ### New schemas

--- a/schema/compiled/service_with_definitions.json
+++ b/schema/compiled/service_with_definitions.json
@@ -3179,6 +3179,79 @@
         "service_id"
       ]
     },
+    "unit": {
+      "name": "unit",
+      "path": "units.csv",
+      "description": "The details of units which are used to measure service capacity.",
+      "datapackage_metadata": {
+        "format": "csv",
+        "mediatype": "text/csv",
+        "profile": "tabular-data-resource",
+        "order": 99
+      },
+      "type": "object",
+      "properties": {
+        "id": {
+          "name": "id",
+          "type": "string",
+          "format": "uuid",
+          "title": "Identifier",
+          "description": "The identifier for the unit object. Each unit must have a unique identifier.",
+          "example": "8896b788-7b3e-11ef-8db9-7f3d040352b3"
+        },
+        "name": {
+          "name": "name",
+          "type": "string",
+          "title": "Name",
+          "description": "The human-readable name for this unit e.g. \u201cBed\u201d or \u201cHours\u201d",
+          "example": "Kilogram"
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "string",
+          "title": "Scheme",
+          "description": "The scheme which formalizes the unit, if applicable e.g. \u201cSI\u201d for Standard International Units such as Kilogram, Litre, etc.",
+          "example": "SI"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "string",
+          "title": "Unit Identifier",
+          "description": "The identifier of the unit taken from the scheme if applicable e.g. `kgm` for Kilogram.",
+          "example": "kgm"
+        },
+        "uri": {
+          "name": "uri",
+          "type": "string",
+          "format": "uri",
+          "title": "URI",
+          "description": "The URI to the definition of the unit, if applicable",
+          "example": "https://not-a-real-url.org/standard-international-units/kgm"
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "array",
+          "title": "Attributes",
+          "description": "A link between a service and one or more classifications that describe the nature of the service provided.",
+          "items": {
+            "$ref": "#/definitions/attribute"
+          }
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "array",
+          "title": "Metadata",
+          "description": "A record of the changes that have been made to the data in order to maintain provenance information.",
+          "items": {
+            "$ref": "#/definitions/metadata"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
+    },
     "url": {
       "name": "url",
       "path": "url.csv",
@@ -3265,79 +3338,6 @@
       "required": [
         "id",
         "url"
-      ]
-    },
-    "unit": {
-      "name": "unit",
-      "path": "units.csv",
-      "description": "The details of units which are used to measure service capacity.",
-      "datapackage_metadata": {
-        "format": "csv",
-        "mediatype": "text/csv",
-        "profile": "tabular-data-resource",
-        "order": 99
-      },
-      "type": "object",
-      "properties": {
-        "id": {
-          "name": "id",
-          "type": "string",
-          "format": "uuid",
-          "title": "Identifier",
-          "description": "The identifier for the unit object. Each unit must have a unique identifier.",
-          "example": "8896b788-7b3e-11ef-8db9-7f3d040352b3"
-        },
-        "name": {
-          "name": "name",
-          "type": "string",
-          "title": "Name",
-          "description": "The human-readable name for this unit e.g. \u201cBed\u201d or \u201cHours\u201d",
-          "example": "Kilogram"
-        },
-        "scheme": {
-          "name": "scheme",
-          "type": "string",
-          "title": "Scheme",
-          "description": "The scheme which formalizes the unit, if applicable e.g. \u201cSI\u201d for Standard International Units such as Kilogram, Litre, etc.",
-          "example": "SI"
-        },
-        "identifier": {
-          "name": "identifier",
-          "type": "string",
-          "title": "Unit Identifier",
-          "description": "The identifier of the unit taken from the scheme if applicable e.g. `kgm` for Kilogram.",
-          "example": "kgm"
-        },
-        "uri": {
-          "name": "uri",
-          "type": "string",
-          "format": "uri",
-          "title": "URI",
-          "description": "The URI to the definition of the unit, if applicable",
-          "example": "https://not-a-real-url.org/standard-international-units/kgm"
-        },
-        "attributes": {
-          "name": "attributes",
-          "type": "array",
-          "title": "Attributes",
-          "description": "A link between a service and one or more classifications that describe the nature of the service provided.",
-          "items": {
-            "$ref": "#/definitions/attribute"
-          }
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "array",
-          "title": "Metadata",
-          "description": "A record of the changes that have been made to the data in order to maintain provenance information.",
-          "items": {
-            "$ref": "#/definitions/metadata"
-          }
-        }
-      },
-      "required": [
-        "id",
-        "name"
       ]
     }
   }

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -833,7 +833,8 @@
             "type": "boolean",
             "description": "A Boolean value indicating if there is an empty result set"
           }
-        }
+        },
+        "required": ["empty"]
       }
     },
     "parameters": {


### PR DESCRIPTION
**Related issues**

(https://github.com/openreferral/specification/issues/514)

**Description**
- Makes Page.empty a required field 
- Updates the changelog 

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [ ] Update the changelog

If you have edited any schema files:

- [ ] Run `hsds_schema.py` to update `datapackage.json` and example files
- [ ] Update the [logical model](http://docs.openreferral.org/en/latest/hsds/logical_model/) page if relevant
