### PR TITLE
github actions: Upgrade versions of actions and remove cache action

### DIFF
--- a/.github/workflows/build_database.yml
+++ b/.github/workflows/build_database.yml
@@ -21,9 +21,9 @@ jobs:
 #          --health-timeout 5s
 #          --health-retries 20
 #    steps:
-#    - uses: actions/checkout@v2
+#    - uses: actions/checkout@v4
 #    - name: Setup python
-#      uses: actions/setup-python@v2
+#      uses: actions/setup-python@v5
 #      with:
 #        python-version: 3.9
 #        architecture: x64
@@ -69,9 +69,9 @@ jobs:
         ports:
           - 5432:5432/tcp
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         architecture: x64

--- a/.github/workflows/has_hsds_schema_py_been_run.yml
+++ b/.github/workflows/has_hsds_schema_py_been_run.yml
@@ -5,17 +5,13 @@ jobs:
   has_hsds_schema_py_been_run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         architecture: x64
     - run: sudo apt-get install graphviz libgraphviz-dev pkg-config
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     - run: pip install -r requirements.txt
     - run: hsds_schema.py docs-all
     - run: git diff --exit-code

--- a/.github/workflows/test_examples_datapackage.yml
+++ b/.github/workflows/test_examples_datapackage.yml
@@ -5,16 +5,12 @@ jobs:
   test_examples_datapackage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-test_examples
     - name: Install Python libs
       run: pip install --upgrade frictionless
     - name: Validate example

--- a/.github/workflows/test_examples_json_schema.yml
+++ b/.github/workflows/test_examples_json_schema.yml
@@ -5,16 +5,12 @@ jobs:
   test_examples_json_schema:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         architecture: x64
     - run: sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     - run: pip install -r requirements.txt
     - run: ./validate_examples_json_schema.sh

--- a/.github/workflows/test_examples_openapi.yml
+++ b/.github/workflows/test_examples_openapi.yml
@@ -5,7 +5,7 @@ jobs:
   test_examples_openapi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Node.js
       uses: actions/setup-node@v3
     - run: npm install -g openapi-examples-validator

--- a/.github/workflows/test_schemas.yml
+++ b/.github/workflows/test_schemas.yml
@@ -5,17 +5,13 @@ jobs:
   test_schemas:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         architecture: x64
     - run: sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
     - run: pip install -r requirements.txt
     - name: Check the json schemas validate against the metaschema
       run: check-jsonschema schema/*.json --check-metaschema


### PR DESCRIPTION
v1 of cache action now broken - just remove for now till we are clear how best to use caching

Only changes to build tools so normal PR template (eg Changelog) not relevant.