### PR TITLE
PATCH: Fix OpenAPI Schema Reference

### DIFF
--- a/database/database_postgresql.sql
+++ b/database/database_postgresql.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 5lD4WUoeuggr8s3pfCfs9CLY6YIy2sTi916uQD0yUU8MpFN0fglsmkHhngXtr0n
+\restrict NwvVkHoh5eZGgN74uKejsEIc4cq5ycgP54UAlJgjqp3OSdX5MAT3QAeJmz484GC
 
 
 SET statement_timeout = 0;
@@ -2445,5 +2445,5 @@ ALTER TABLE ONLY public.url
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 5lD4WUoeuggr8s3pfCfs9CLY6YIy2sTi916uQD0yUU8MpFN0fglsmkHhngXtr0n
+\unrestrict NwvVkHoh5eZGgN74uKejsEIc4cq5ycgP54UAlJgjqp3OSdX5MAT3QAeJmz484GC
 

--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -752,7 +752,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location.json"
                 }
               }
             }

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -3,6 +3,12 @@ Changelog
 
 This page provides the list of changes that have been made to the HSDS schema.
 
+## [v3.2.1](https://github.com/openreferral/specification/releases/tag/v3.2.1)
+
+### Bugfixes
+
+* Fixed a bug where the `GET /service_at_locations/{id}` endpoint was declared as returning an instance of `service.json`. It now correctly declares that it returns an instance of `service_at_location.json`.
+
 ## [v3.2](https://github.com/openreferral/specification/releases/tag/v3.2)
 
 ### New codelists

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -759,7 +759,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location.json"
                 }
               }
             }


### PR DESCRIPTION
- **schema/docs: GET /service_at_locations/{id} return**
- **docs: ran hsds_schema_tools docs-all**

**Description**

This PATCH fixes a bug with the `openapi.json` file which incorrectly declared the return type of the API Endpoint `GET /service_at_locations/{id}`.

This was previously declared as being an instance of the (compiled) `service.json` schema, which is incorrect since there exists a compiled `service_at_location.json` schema.

This PR addresses this bug, and adds an entry to the changelog which reflects it. The entry in the changelog is pre-emptively hyperlinked to the release of HSDS which would result in this PATCH being merged.


**Merge checklist**

- [*] Update the changelog

If you have edited any schema files:

- [*] Run `hsds_schema.py` to update `datapackage.json` and example files
