### PR TITLE
PATCH: Bugfix 3.2 openapi ref errors

### DIFF
--- a/database/database_postgresql.sql
+++ b/database/database_postgresql.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict 6qEnhLpFQqXRB76bi15NnZoBurcoOgYtSmQSBsyZbJfQaqmk97MTWYyl1tGFhtE
+\restrict wouP6kG48W44CTYX5iNz0eiWbJqfA30TIyZWXbp3Upy6E7ZCABJYbwMn6AQ0TgD
 
 
 SET statement_timeout = 0;
@@ -2445,5 +2445,5 @@ ALTER TABLE ONLY public.url
 -- PostgreSQL database dump complete
 --
 
-\unrestrict 6qEnhLpFQqXRB76bi15NnZoBurcoOgYtSmQSBsyZbJfQaqmk97MTWYyl1tGFhtE
+\unrestrict wouP6kG48W44CTYX5iNz0eiWbJqfA30TIyZWXbp3Upy6E7ZCABJYbwMn6AQ0TgD
 

--- a/database/database_postgresql.sql
+++ b/database/database_postgresql.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict YN7tVkxQMepU09IbFJeeuZLuqBxv1hbK7hOiMQNQe3FuYb9VIciZWSe7ROol6aW
+\restrict 6qEnhLpFQqXRB76bi15NnZoBurcoOgYtSmQSBsyZbJfQaqmk97MTWYyl1tGFhtE
 
 
 SET statement_timeout = 0;
@@ -2445,5 +2445,5 @@ ALTER TABLE ONLY public.url
 -- PostgreSQL database dump complete
 --
 
-\unrestrict YN7tVkxQMepU09IbFJeeuZLuqBxv1hbK7hOiMQNQe3FuYb9VIciZWSe7ROol6aW
+\unrestrict 6qEnhLpFQqXRB76bi15NnZoBurcoOgYtSmQSBsyZbJfQaqmk97MTWYyl1tGFhtE
 

--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -131,7 +131,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service.json"
                 }
               }
             }
@@ -191,7 +191,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -257,7 +257,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -298,7 +298,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                 }
               }
             }
@@ -338,7 +338,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                       }
                     }
                   },
@@ -384,7 +384,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                       }
                     }
                   },
@@ -425,7 +425,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                 }
               }
             }
@@ -486,7 +486,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -553,7 +553,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -599,7 +599,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization.json"
                 }
               }
             }
@@ -652,7 +652,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -711,7 +711,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -752,7 +752,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location.json"
                 }
               }
             }
@@ -814,7 +814,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },
@@ -882,7 +882,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -3,6 +3,13 @@ Changelog
 
 This page provides the list of changes that have been made to the HSDS schema.
 
+## [v3.2.2](https://github.com/openreferral/specification/releases/tag/v3.2.2)
+
+* Fixed a big where the `openapi.json` file was referring to schemas from the HSDS 3.0 version
+
+### Bugfixes
+
+
 ## [v3.2.1](https://github.com/openreferral/specification/releases/tag/v3.2.1)
 
 ### Bugfixes

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -138,7 +138,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service.json"
                 }
               }
             }
@@ -198,7 +198,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -264,7 +264,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -305,7 +305,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                 }
               }
             }
@@ -345,7 +345,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                       }
                     }
                   },
@@ -391,7 +391,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy.json"
                       }
                     }
                   },
@@ -432,7 +432,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                 }
               }
             }
@@ -493,7 +493,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -560,7 +560,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -606,7 +606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization.json"
                 }
               }
             }
@@ -659,7 +659,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -718,7 +718,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -759,7 +759,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location.json"
                 }
               }
             }
@@ -821,7 +821,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },
@@ -889,7 +889,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.2/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },


### PR DESCRIPTION
**Description**

The `$ref` values for the schemas in `openapi.json` were still referring to the HSDS 3.0 schemas, which would cause validation errors.

This PR fixes that for the latest version of HSDS, and will result in a new PATCH version.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog

If you have edited any schema files:

- [x] Run `hsds_schema.py` to update `datapackage.json` and example files
