### PR TITLE
PATCH: Bugfix for v3.1 openapi ref errors

### DIFF
--- a/database/database_postgresql.sql
+++ b/database/database_postgresql.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict b3XDSjlClxSt1YtUAwEPzYUCbYoz3dWk3xCqD8DHC6wcSmHPfqXXbM0KXH8x67a
+\restrict x7YNhcAXQ7NW9dCw5pF6JY4TgkufNrRTAvEHMMb4W17Qv4Qwmz39G2xAHFU7utg
 
 
 SET statement_timeout = 0;
@@ -2445,5 +2445,5 @@ ALTER TABLE ONLY public.url
 -- PostgreSQL database dump complete
 --
 
-\unrestrict b3XDSjlClxSt1YtUAwEPzYUCbYoz3dWk3xCqD8DHC6wcSmHPfqXXbM0KXH8x67a
+\unrestrict x7YNhcAXQ7NW9dCw5pF6JY4TgkufNrRTAvEHMMb4W17Qv4Qwmz39G2xAHFU7utg
 

--- a/database/database_postgresql.sql
+++ b/database/database_postgresql.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict Y3Pr6YIEkLe040ZZglTkAtqTz4huBsf1CGGzSvAXvQ1e8S2eQHVxrfhNhBKaND9
+\restrict b3XDSjlClxSt1YtUAwEPzYUCbYoz3dWk3xCqD8DHC6wcSmHPfqXXbM0KXH8x67a
 
 
 SET statement_timeout = 0;
@@ -2445,5 +2445,5 @@ ALTER TABLE ONLY public.url
 -- PostgreSQL database dump complete
 --
 
-\unrestrict Y3Pr6YIEkLe040ZZglTkAtqTz4huBsf1CGGzSvAXvQ1e8S2eQHVxrfhNhBKaND9
+\unrestrict b3XDSjlClxSt1YtUAwEPzYUCbYoz3dWk3xCqD8DHC6wcSmHPfqXXbM0KXH8x67a
 

--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -67,7 +67,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service.json"
                 }
               }
             }
@@ -124,7 +124,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -187,7 +187,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -225,7 +225,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                 }
               }
             }
@@ -262,7 +262,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                       }
                     }
                   },
@@ -305,7 +305,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                       }
                     }
                   },
@@ -343,7 +343,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                 }
               }
             }
@@ -401,7 +401,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -465,7 +465,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -508,7 +508,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization.json"
                 }
               }
             }
@@ -558,7 +558,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -614,7 +614,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -652,7 +652,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service.json"
                 }
               }
             }
@@ -711,7 +711,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },
@@ -776,7 +776,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -3,6 +3,13 @@ Changelog
 
 This page provides the list of changes that have been made to the HSDS schema.
 
+
+## [v3.1.2](https://github.com/openreferral/specification/releases/tag/v3.1.2)
+
+### Bugfixes
+
+* Fixed `$ref` values inside `openapi.json` which were pointing to an older version of HSDS schemas
+
 ## [v3.1.1](https://github.com/openreferral/specification/releases/tag/v3.1.1)
 
 * Made `Page.Empty` a required field for API responses

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -74,7 +74,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service.json"
                 }
               }
             }
@@ -131,7 +131,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -194,7 +194,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
                       }
                     }
                   },
@@ -232,7 +232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                 }
               }
             }
@@ -269,7 +269,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                       }
                     }
                   },
@@ -312,7 +312,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
                       }
                     }
                   },
@@ -350,7 +350,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                 }
               }
             }
@@ -408,7 +408,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -472,7 +472,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
                       }
                     }
                   },
@@ -515,7 +515,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization.json"
                 }
               }
             }
@@ -565,7 +565,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -621,7 +621,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
                       }
                     }
                   },
@@ -659,7 +659,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service.json"
+                  "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service.json"
                 }
               }
             }
@@ -718,7 +718,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },
@@ -783,7 +783,7 @@
                     "contents": {
                       "type": "array",
                       "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
                       }
                     }
                   },


### PR DESCRIPTION
**Related issues**

Related to #580, but for an older version of HSDS.

Semantic versioning allows us to issue PATCHes for older releases, so this PR does the same fix but for HSDS 3.1. This allows Profiles etc. based on older versions of HSDS to benefit from these changes.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog

If you have edited any schema files:

- [x] Run `hsds_schema.py` to update `datapackage.json` and example files
