### PR TITLE
Fix: Standardize allOf and Page schema structure for OpenAPI compliance

### DIFF
--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -120,17 +120,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -183,17 +189,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -258,17 +270,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -301,17 +319,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -336,7 +360,7 @@
       "get": {
         "description": "Full information on a taxonomy term.",
         "summary": "Full information on a taxonomy term.",
-        "operationId": "getPaginatedListOfTaxonomyTerms",
+        "operationId": "getTaxonomyTermById",
         "responses": {
           "200": {
             "description": "Full information on a taxonomy term.",
@@ -355,7 +379,7 @@
       "get": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -397,17 +421,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -419,7 +449,7 @@
       "post": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -461,17 +491,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -554,17 +590,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -610,17 +652,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -707,17 +755,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -772,17 +826,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -3,6 +3,12 @@ Changelog
 
 This page provides the list of changes that have been made to the HSDS schema.
 
+## [v3.1.3](https://github.com/openreferral/specification/releases/tag/v3.1.3)
+
+### Bugfixes
+
+* **Refactored Schema Composition:** Standardized paginated response models by moving `allOf` to the root level. This resolves validation failures caused by sibling `properties` conflicts in tools like Spectral and Swagger Editor.
+* **Fixed Endpoint Naming:** Corrected the inverted `operationId` values for `/taxonomy_terms` and `/taxonomy_terms/{id}` to prevent incorrect client SDK method generation.
 
 ## [v3.1.2](https://github.com/openreferral/specification/releases/tag/v3.1.2)
 

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -359,7 +359,7 @@
       "get": {
         "description": "Full information on a taxonomy term.",
         "summary": "Full information on a taxonomy term.",
-        "operationId": "getPaginatedListOfTaxonomyTerms",
+        "operationId": "getTaxonomyTermById",
         "responses": {
           "200": {
             "description": "Full information on a taxonomy term.",
@@ -378,7 +378,7 @@
       "get": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -127,17 +127,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -190,17 +194,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -265,17 +273,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -308,17 +320,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -404,17 +420,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -468,17 +488,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -561,17 +585,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -617,17 +645,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -714,17 +746,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -779,17 +815,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.1/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -446,7 +446,7 @@
       "post": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"


### PR DESCRIPTION
- Move allOf to be the primary wrapper instead of sibling to properties
- Add explicit type: object and required fields for contents
- Fixes pagination schema validation issues with modern tools
- Affects 10 paginated endpoints
- Resolves #585
- Resolves #589

**Description**

standardize allOf composition in openapi.json
- Restructured paginated response schemas to use a top-level allOf array.
- Resolved "Sibling Property" conflicts where contents and Page metadata were not merging in validation engines.

Operation ID Correction: 
- Swapped the inverted operationId values for /taxonomy_terms and /taxonomy_terms/{id} to ensure correct mapping 
- in generated client SDKs.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog

If you have edited any schema files:

- [x] Run `hsds_schema.py` to update `datapackage.json` and example files

If you are working towards a new MINOR release:

- [ ] Update any `$id` values in schema files where appropriate
- [ ] Update the `$ref` values in `openapi.json`
