### PR TITLE
Fix: Standardize allOf and Page schema structure for OpenAPI compliance

### DIFF
--- a/docs/extras/openapi30.json
+++ b/docs/extras/openapi30.json
@@ -120,17 +120,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -195,17 +201,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -230,7 +242,7 @@
       "get": {
         "description": "Full information on a taxonomy term.",
         "summary": "Full information on a taxonomy term.",
-        "operationId": "getPaginatedListOfTaxonomyTerms",
+        "operationId": "getTaxonomyTermById",
         "responses": {
           "200": {
             "description": "Full information on a taxonomy term.",
@@ -249,7 +261,7 @@
       "get": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"
@@ -291,17 +303,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -378,17 +396,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }
@@ -475,17 +499,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": [
+                        "contents"
+                      ]
                     }
                   ]
                 }

--- a/docs/hsds/changelog.md
+++ b/docs/hsds/changelog.md
@@ -5,6 +5,13 @@ This page provides the list of changes that have been made to the HSDS schema.
 
 Additional changes made to requirements of UK compliance are provided on a separate Changelog section of the [UK Compliance](uk_compliance.md#changelog) page.
 
+## [v3.0.1](https://github.com/openreferral/specification/releases/tag/v3.0.1)
+
+### Bugfixes
+
+* **Refactored Schema Composition:** Standardized paginated response models by moving `allOf` to the root level. This resolves validation failures caused by sibling `properties` conflicts in tools like Spectral and Swagger Editor.
+* **Fixed Endpoint Naming:** Corrected the inverted `operationId` values for `/taxonomy_terms` and `/taxonomy_terms/{id}` to prevent incorrect client SDK method generation.
+
 ## [v3.0](https://github.com/openreferral/specification/milestone/7)
 
 ### Backwards incompatible schema changes

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -127,17 +127,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -202,17 +206,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -298,17 +306,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/taxonomy_term.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -385,17 +397,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/organization_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }
@@ -482,17 +498,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "contents": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
-                      }
-                    }
-                  },
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/Page"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "contents": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "https://raw.githubusercontent.com/openreferral/specification/3.0/schema/compiled/service_at_location_list.json"
+                          }
+                        }
+                      },
+                      "required": ["contents"]
                     }
                   ]
                 }

--- a/schema/openapi.json
+++ b/schema/openapi.json
@@ -245,7 +245,7 @@
       "get": {
         "description": "Full information on a taxonomy term.",
         "summary": "Full information on a taxonomy term.",
-        "operationId": "getPaginatedListOfTaxonomyTerms",
+        "operationId": "getTaxonomyTermById",
         "responses": {
           "200": {
             "description": "Full information on a taxonomy term.",
@@ -264,7 +264,7 @@
       "get": {
         "description": "Full information on a taxonomy term",
         "summary": "Paginated listing of taxonomy terms",
-        "operationId": "getTaxonomyTermById",
+        "operationId": "getPaginatedListOfTaxonomyTerms",
         "parameters": [
           {
             "$ref": "#/components/parameters/search"


### PR DESCRIPTION
- Move allOf to be the primary wrapper instead of sibling to properties
- Add explicit type: object and required fields for contents
- Fixes pagination schema validation issues with modern tools
- Resolves #585
- Resolves #589

**Description**

standardize allOf composition in openapi.json
- Restructured paginated response schemas to use a top-level allOf array.
- Resolved "Sibling Property" conflicts where contents and Page metadata were not merging in validation engines.

Operation ID Correction: 
- Swapped the inverted operationId values for /taxonomy_terms and /taxonomy_terms/{id} to ensure correct mapping 
- in generated client SDKs.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog

If you have edited any schema files:

- [x] Run `hsds_schema.py` to update `datapackage.json` and example files

If you are working towards a new MINOR release:

- [ ] Update any `$id` values in schema files where appropriate
- [ ] Update the `$ref` values in `openapi.json`
